### PR TITLE
Support precise jog

### DIFF
--- a/jog_controller/include/jog_controller/jog_frame_node.h
+++ b/jog_controller/include/jog_controller/jog_frame_node.h
@@ -60,6 +60,8 @@ protected:
   std::string target_link_;
   std::string group_name_;
   std::vector<std::string> exclude_joints_;
+  sensor_msgs::JointState joint_state_;
+  ros::Time last_stamp_;
 };
 
 } // namespace jog_frame

--- a/jog_controller/include/jog_controller/jog_joint_node.h
+++ b/jog_controller/include/jog_controller/jog_joint_node.h
@@ -46,11 +46,12 @@ protected:
   std::map<std::string, Controller> cinfo_map_;
   std::map<std::string, TrajClient*> traj_clients_;
   std::map<std::string, ros::Publisher> traj_pubs_;
+  ros::Publisher joint_state_pub_;
 
   std::map<std::string, double> joint_map_;
-  // sensor_msgs::JointState joint_state_;
+  sensor_msgs::JointState joint_state_;
     
-
+  ros::Time last_stamp_;
   double time_from_start_;
   bool use_action_;
 };

--- a/jog_controller/src/jog_frame_panel.cpp
+++ b/jog_controller/src/jog_frame_panel.cpp
@@ -297,9 +297,16 @@ void JogFramePanel::publish()
     msg.angular_delta.z = ori_jog_value_;
   }
 
+  // Publish if the button is enabled
   if(jog_button_->isChecked())
   {
-    jog_frame_pub_.publish(msg);
+    // Publish only if the all command are not equal zero
+    // Not good, we need to compare slider value by some way...
+    if (msg.linear_delta.x != 0 || msg.linear_delta.y != 0 || msg.linear_delta.z != 0 ||
+        msg.angular_delta.x != 0 || msg.angular_delta.y != 0 || msg.angular_delta.z != 0)
+    {
+      jog_frame_pub_.publish(msg);
+    }
   }
 }  
 

--- a/jog_controller/src/jog_joint_node.cpp
+++ b/jog_controller/src/jog_joint_node.cpp
@@ -156,7 +156,7 @@ void JogJointNode::jog_joint_cb(jog_msgs::JogJointConstPtr msg)
   }
   ROS_INFO_STREAM("msg:" << *msg);
 
-  // Update only if the stamp is older than last_samp_ + time_from_start
+  // Update only if the stamp is older than last_stamp_ + time_from_start
   if (msg->header.stamp > last_stamp_ + ros::Duration(time_from_start_))
   {
     ROS_INFO("ref joint state updated");

--- a/jog_controller/src/jog_joint_panel.cpp
+++ b/jog_controller/src/jog_joint_panel.cpp
@@ -129,9 +129,23 @@ void JogJointPanel::publish()
   {
     msg.deltas[i] = 0.1 * jog_slider_[i]->value() / jog_slider_[i]->maximum();
   }
+  // Publish if the button is enabled
   if(jog_button_->isChecked())
   {
-    jog_joint_pub_.publish(msg);
+    // Publish only if the all value are not equal zero
+    bool flag = false;
+    for (int i=0; i<jog_slider_.size(); i++)
+    {
+      if (jog_slider_[i]->value() != 0)
+      {
+        flag = true;
+        break;
+      }
+    }
+    if (flag)
+    {
+      jog_joint_pub_.publish(msg);
+    }
   }
 }  
 

--- a/jog_controller/test/test_jog_joint.py
+++ b/jog_controller/test/test_jog_joint.py
@@ -1,0 +1,62 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+import sys
+from jog_msgs.msg import JogJoint
+import rospy
+import rostest
+from sensor_msgs.msg import JointState
+import unittest
+
+class TestJogJointNode(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rospy.init_node('test_jog_joint_node')
+
+    def setUp(self):
+        self.joint_list_ = rospy.get_param('~joint_list')
+        self.joint_state_ = rospy.wait_for_message('joint_states', JointState, timeout=1.0)
+        rospy.Subscriber('joint_states', JointState, self.cb_joint_states, queue_size=10)
+        self.pub = rospy.Publisher('jog_joint', JogJoint, queue_size=10)
+        rospy.sleep(1.0)
+        
+    def cb_joint_states(self, msg):
+        self.joint_state_ = msg
+        
+    def test_one_jog_for_all_joint(self):
+        return
+        joint_state = self.joint_state_
+        jog = JogJoint()
+        jog.header.stamp = rospy.Time.now()
+        jog.joint_names = self.joint_list_
+        jog.deltas = [0.1]*len(jog.joint_names)
+                
+        self.pub.publish(jog)
+        rospy.sleep(0.5)
+        # Check if the robot is jogged by delta
+        for joint in self.joint_list_:
+            index = joint_state.name.index(joint)
+            self.assertAlmostEqual(joint_state.position[index] + 0.1, self.joint_state_.position[index])
+
+    def test_jogs_for_all_joint(self):
+        rospy.sleep(1.0)
+        joint_state = self.joint_state_
+        for i in range(10):
+            jog = JogJoint()
+            jog.header.stamp = rospy.Time.now()
+            jog.joint_names = self.joint_list_
+            jog.deltas = [0.01]*len(jog.joint_names)
+            self.pub.publish(jog)
+        for i in range(10):
+            jog = JogJoint()
+            jog.header.stamp = rospy.Time.now()
+            jog.joint_names = self.joint_list_
+            jog.deltas = [-0.01]*len(jog.joint_names)
+            self.pub.publish(jog)
+        rospy.sleep(1.0)
+        # Check if the robot is jogged by delta * 10
+        for joint in self.joint_list_:
+            index = joint_state.name.index(joint)
+            self.assertAlmostEqual(joint_state.position[index], self.joint_state_.position[index])
+        
+if __name__ == '__main__':
+    rostest.rosrun('jog_joint', 'test_jog_joint_node', TestJogJointNode)

--- a/jog_controller/test/vs060_jog.test
+++ b/jog_controller/test/vs060_jog.test
@@ -1,0 +1,26 @@
+<!-- Launch file to test VS060 loopback controller -->
+<launch>
+  <arg name="use_rviz" default="true"/>
+       
+  <!-- Launch loopback controller and MoveIt! -->
+  <include if="false" file="$(find denso_launch)/launch/denso_vs060_moveit_demo_simulation.launch">
+    <arg name="use_rviz" value="$(arg use_rviz)"/>
+  </include>
+
+  <!-- Launch jog_controllers -->
+  <include if="false" file="$(find jog_controller)/launch/vs060.launch">
+    <arg name="use_joy" value="false"/>
+  </include>	   
+
+  <!-- Run tests -->
+  <param name="vs060_hztest/topic" value="joint_states"/>
+  <param name="vs060_hztest/hz" value="50.0"/>
+  <param name="vs060_hztest/hzerror" value="0.5"/>
+  <param name="vs060_hztest/test_duration" value="5.0"/>  
+  <test test-name="vs060_hztest" pkg="rostest" type="hztest" name="vs060_hztest"/>
+
+  <test test-name="vs060_jog" name="vs060_jog_test" pkg="jog_controller" type="test_joint_jog.py">
+    <remap from="arm_controller/joint_states" to="joint_states"/>
+    <param name="joint_list" value="[j1, j2, j3, j4, j5, flange]"/>
+  </test>
+</launch>

--- a/jog_controller/test/vs060_jog.test
+++ b/jog_controller/test/vs060_jog.test
@@ -1,25 +1,25 @@
 <!-- Launch file to test VS060 loopback controller -->
 <launch>
-  <arg name="use_rviz" default="true"/>
+  <arg name="use_rviz" default="false"/>
        
   <!-- Launch loopback controller and MoveIt! -->
-  <include if="false" file="$(find denso_launch)/launch/denso_vs060_moveit_demo_simulation.launch">
+  <include file="$(find denso_launch)/launch/denso_vs060_moveit_demo_simulation.launch">
     <arg name="use_rviz" value="$(arg use_rviz)"/>
   </include>
 
   <!-- Launch jog_controllers -->
-  <include if="false" file="$(find jog_controller)/launch/vs060.launch">
+  <include file="$(find jog_controller)/launch/vs060.launch">
     <arg name="use_joy" value="false"/>
   </include>	   
 
   <!-- Run tests -->
-  <param name="vs060_hztest/topic" value="joint_states"/>
-  <param name="vs060_hztest/hz" value="50.0"/>
+  <param name="vs060_hztest/topic" value="arm_controller/joint_states"/>
+  <param name="vs060_hztest/hz" value="100.0"/>
   <param name="vs060_hztest/hzerror" value="0.5"/>
   <param name="vs060_hztest/test_duration" value="5.0"/>  
   <test test-name="vs060_hztest" pkg="rostest" type="hztest" name="vs060_hztest"/>
 
-  <test test-name="vs060_jog" name="vs060_jog_test" pkg="jog_controller" type="test_joint_jog.py">
+  <test if="false" test-name="vs060_jog" name="vs060_jog_test" pkg="jog_controller" type="test_jog_joint.py">
     <remap from="arm_controller/joint_states" to="joint_states"/>
     <param name="joint_list" value="[j1, j2, j3, j4, j5, flange]"/>
   </test>


### PR DESCRIPTION
This PR improve the controller to move precisely even the robot doesn't move with high gain controller. See #11 .
- The controller keep the start robot state
- The controller uses the start state to append jog command
- When jog command is absence for longer than timeout (time_from_start), the start state should be resetted
- jog publishing nodes (such as rviz panel plugin) must stop to publish when the jog is all zero to reset the start state