### PR TITLE
Add `intermittent` parameter

### DIFF
--- a/jog_controller/include/jog_controller/jog_frame_node.h
+++ b/jog_controller/include/jog_controller/jog_frame_node.h
@@ -56,6 +56,7 @@ protected:
 
   double time_from_start_;
   bool use_action_;
+  bool intermittent_;
 
   std::string target_link_;
   std::string group_name_;

--- a/jog_controller/include/jog_controller/jog_joint_node.h
+++ b/jog_controller/include/jog_controller/jog_joint_node.h
@@ -54,6 +54,7 @@ protected:
   ros::Time last_stamp_;
   double time_from_start_;
   bool use_action_;
+  bool intermittent_;
 };
 
 } // namespace jog_joint

--- a/jog_controller/src/jog_frame_node.cpp
+++ b/jog_controller/src/jog_frame_node.cpp
@@ -288,6 +288,8 @@ void JogFrameNode::jog_frame_cb(jog_msgs::JogFrameConstPtr msg)
     return;
   }
 
+  // ROS_INFO_STREAM("ik response:\n" << ik.response);
+  
   auto state = ik.response.solution.joint_state;
   geometry_msgs::PoseStamped pose_check;
   
@@ -310,10 +312,9 @@ void JogFrameNode::jog_frame_cb(jog_msgs::JogFrameConstPtr msg)
   }
   if (error > M_PI / 2)
   {
-    ROS_WARN_STREAM("**** Validation check Failed: " << error);
+    ROS_ERROR_STREAM("**** Validation check Failed: " << error);
     return;
   }
-  
   // Publish trajectory message for each controller
   for (auto it=cinfo_map_.begin(); it!=cinfo_map_.end(); it++)
   {

--- a/jog_controller/src/jog_frame_node.cpp
+++ b/jog_controller/src/jog_frame_node.cpp
@@ -81,6 +81,13 @@ JogFrameNode::JogFrameNode()
   pnh.param<std::string>("group", group_name_);
   pnh.param<double>("time_from_start", time_from_start_, 0.5);
   pnh.param<bool>("use_action", use_action_, false);
+  pnh.param<bool>("intermittent", intermittent_, false);
+
+  if (not use_action_ && intermittent_)
+  {
+    ROS_WARN("'intermittent' param should be true with 'use_action'. Assuming to use action'");
+    use_action_ = true;
+  }
   // Exclude joint list
   gnh.getParam("exclude_joint_names", exclude_joints_);
 
@@ -154,6 +161,20 @@ JogFrameNode::JogFrameNode()
 void JogFrameNode::jog_frame_cb(jog_msgs::JogFrameConstPtr msg)
 {
   joint_state_.header.stamp = ros::Time::now();
+
+  // In intermittent mode, confirm to all of the action is completed
+  if (intermittent_)
+  {
+    for (auto it=cinfo_map_.begin(); it!=cinfo_map_.end(); it++)
+    {
+      auto controller_name = it->first;
+      actionlib::SimpleClientGoalState state = traj_clients_[controller_name]->getState();
+      if (state == actionlib::SimpleClientGoalState::ACTIVE)
+      {
+        return;
+      }
+    }    
+  }
   // Update reference frame only if the stamp is older than last_stamp_ + time_from_start_
   if (msg->header.stamp > last_stamp_ + ros::Duration(time_from_start_))
   {

--- a/jog_launch/config/i611_jog.yaml
+++ b/jog_launch/config/i611_jog.yaml
@@ -1,0 +1,14 @@
+jog_joint_node:
+  joint_names:
+    - Joint1
+    - Joint2
+    - Joint3
+    - Joint4
+    - Joint5
+    - Joint6
+
+jog_frame_node:
+  group_names:
+    - manipulator
+  link_names:
+    - Link6

--- a/jog_launch/launch/i611.launch
+++ b/jog_launch/launch/i611.launch
@@ -1,0 +1,30 @@
+<launch>
+  <arg name="use_rviz" default="false"/>
+  <arg name="use_joy" default="false"/>
+  <arg name="use_action" default="true"/>
+  <arg name="intermittent" default="true"/>
+
+  <!-- Launch rviz -->
+  <node if="$(arg use_rviz)"
+	name="rviz" pkg="rviz" type="rviz"
+	args="-d $(find jog_launch)/launch/jog.rviz"/>
+  
+  <rosparam command="load" file="$(find jog_launch)/config/i611_jog.yaml"/>
+
+  <node name="jog_joint_node" pkg="jog_controller" type="jog_joint_node">
+    <param name="use_action" value="$(arg use_action)"/>
+    <param name="intermittent" value="$(arg intermittent)"/>
+  </node>
+  <node name="jog_frame_node" pkg="jog_controller" type="jog_frame_node">
+    <param name="use_action" value="$(arg use_action)"/>
+    <param name="intermittent" value="$(arg intermittent)"/>
+  </node>
+
+  <!-- Launch joypad -->
+  <include if="$(arg use_joy)" file="$(find jog_controller)/launch/joypad.launch">
+    <arg name="group_name" value="manipulator"/>
+    <arg name="frame_id" value="base_link"/>
+    <arg name="link_name" value="Link6"/>
+  </include>
+
+</launch>

--- a/jog_launch/launch/nextage.launch
+++ b/jog_launch/launch/nextage.launch
@@ -3,6 +3,8 @@
   <arg name="use_moveit" default="false"/>
   <arg name="use_rviz" default="false"/>
   <arg name="use_joy" default="false"/>
+  <arg name="use_action" default="false"/>
+  <arg name="intermittent" default="false"/>
   
   <!-- Launch fake_joint_launch -->
   <include if="$(arg use_fake_joint)"
@@ -23,8 +25,14 @@
   
   <!-- Launch jog_controllers -->
   <rosparam command="load" file="$(find jog_launch)/config/nextage_jog.yaml"/>
-  <node name="jog_joint_node" pkg="jog_controller" type="jog_joint_node"/>
+  <node name="jog_joint_node" pkg="jog_controller" type="jog_joint_node">
+    <param name="use_action" value="$(arg use_action)"/>
+    <param name="intermittent" value="$(arg intermittent)"/>
+  </node>
+    
   <node name="jog_frame_node" pkg="jog_controller" type="jog_frame_node">
+    <param name="use_action" value="$(arg use_action)"/>
+    <param name="intermittent" value="$(arg intermittent)"/>
   </node>
 
   <!-- Launch joypad -->

--- a/jog_launch/launch/tra1.launch
+++ b/jog_launch/launch/tra1.launch
@@ -3,6 +3,8 @@
   <arg name="use_moveit" default="false"/>
   <arg name="use_rviz" default="false"/>
   <arg name="use_joy" default="false"/>
+  <arg name="use_action" default="false"/>
+  <arg name="intermittent" default="false"/>
 
   <!-- Launch fake_joint_launch -->
   <include if="$(arg use_fake_joint)"
@@ -29,8 +31,15 @@
   <!-- Jog controllers -->
   <rosparam command="load"
 	    file="$(find jog_launch)/config/tra1_jog.yaml"/>
-  <node name="jog_joint_node" pkg="jog_controller" type="jog_joint_node"/>
-  <node name="jog_frame_node" pkg="jog_controller" type="jog_frame_node"/>
+  <node name="jog_joint_node" pkg="jog_controller" type="jog_joint_node">
+    <param name="use_action" value="$(arg use_action)"/>
+    <param name="intermittent" value="$(arg intermittent)"/>
+  </node>
+    
+  <node name="jog_frame_node" pkg="jog_controller" type="jog_frame_node">
+    <param name="use_action" value="$(arg use_action)"/>
+    <param name="intermittent" value="$(arg intermittent)"/>
+  </node>
 
   <!-- Launch joypad -->
   <include if="$(arg use_joy)" file="$(find jog_controller)/launch/joypad.launch">

--- a/jog_launch/launch/ur5.launch
+++ b/jog_launch/launch/ur5.launch
@@ -3,6 +3,8 @@
   <arg name="use_moveit" default="false"/>
   <arg name="use_rviz" default="false"/>
   <arg name="use_joy" default="false"/>
+  <arg name="use_action" default="false"/>
+  <arg name="intermittent" default="false"/>
 
   <!-- Launch fake_joint_launch -->
   <include if="$(arg use_fake_joint)"
@@ -20,9 +22,13 @@
 	args="-d $(find jog_launch)/launch/jog.rviz"/>
   
   <rosparam command="load" file="$(find jog_launch)/config/ur_jog.yaml"/>
-  <node name="jog_joint_node" pkg="jog_controller" type="jog_joint_node"/>
+  <node name="jog_joint_node" pkg="jog_controller" type="jog_joint_node">
+    <param name="use_action" value="$(arg use_action)"/>
+    <param name="intermittent" value="$(arg intermittent)"/>
+  </node>
   <node name="jog_frame_node" pkg="jog_controller" type="jog_frame_node">
-    <param name="use_action" value="true"/>
+    <param name="use_action" value="$(arg use_action)"/>
+    <param name="intermittent" value="$(arg intermittent)"/>
   </node>
 
   <!-- Launch joypad -->


### PR DESCRIPTION
This PR is for the robots which don't have the capability of continuous overriding of the target trajectory.
`intermittent` parameter is introduced. When this parameter true, jog motions wait for the end of previous action. It should work for #30 and some robots (NEXTAGE, baxter, etc.) which seems not support continuous target trajectory operations.